### PR TITLE
Sample soil properties from ranges and apply to flux calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ samples within these ranges (e.g., temperature offsets, humidity, precipitation
 probabilities), enabling Monte Carlo style analyses rather than relying on single
 deterministic values.
 
+Recent updates extend this approach to key soil parameters:
+
+* **`k_soil_range` (0.8–1.6 W m⁻¹ K⁻¹):** captures thermal conductivity from
+  organic to mineral soils.
+* **`SWC_max_mm_range` (100–200 mm):** represents field capacity from coarse
+  sandy to loamy soils.
+* **`T_deep_boundary_range` (268–272 K):** bounds the deep soil temperature
+  around the near-freezing permafrost layer.
+
+These ranges inform the Monte Carlo sampling so that each simulation draws a
+physically plausible combination of soil properties.
+
 ## Installation
 
 This project uses Python. We recommend using `uv` to manage dependencies in a virtual environment.


### PR DESCRIPTION
## Summary
- Introduce ranges for `k_soil`, `SWC_max_mm`, and `T_deep_boundary` and sample them per simulation.
- Use sampled soil parameters in heat and water flux routines for both model variants.
- Document soil parameter bounds and rationale in README.

## Testing
- `python -m py_compile energy_balance_rc.py energy_balance_rc_bck.py`
- `python energy_balance_rc.py`

------
https://chatgpt.com/codex/tasks/task_e_688ebd46b73483218e2af590e412e002