### PR TITLE
Add ranged phenology day selection

### DIFF
--- a/energy_balance_rc.py
+++ b/energy_balance_rc.py
@@ -89,9 +89,9 @@ def get_model_config() -> Dict[str, Any]:
         summer_day_start=150, summer_day_end=250, shoulder_1_start=90,
         shoulder_1_end=150, shoulder_2_start=250, shoulder_2_end=300,
         snow_season_end=120, snow_season_start=280,
-        # --- Phenology (Fixed) --------------------------------------------
-        growth_day=140, fall_day=270, growth_rate=0.1, fall_rate=0.1,
-        woody_area_index=0.35,
+        # --- Phenology (Ranged) -------------------------------------------
+        growth_day_range=(130, 150), fall_day_range=(260, 280),
+        growth_rate=0.1, fall_rate=0.1, woody_area_index=0.35,
         # --- Trunk parameters (Fixed) -------------------------------------
         A_trunk_plan=0.03, A_trunk_vert=0.08, k_ct_base_con=0.18,
         k_ct_base_dec=0.12, d_ct=0.1, A_c2t=0.08, k_tsn=0.05, d_tsn=0.1,
@@ -213,7 +213,7 @@ def update_dynamic_parameters(p: Dict, day: int, hour: float, S: dict, L: float,
               np.cos(np.deg2rad(p['latitude_deg'])) * np.cos(np.deg2rad(decl)) * np.cos(np.deg2rad(15 * (hour - 12))))
     p["Q_solar"] = max(0.0, 1000.0 * cos_tz)
 
-    # --- Leaf phenology (mixed species) -----------------------------------
+    # --- Leaf phenology (mixed species; sampled growth/fall days) ---------
     leaf_on = 1 / (1 + np.exp(-p['growth_rate'] * (day - p['growth_day'])))
     leaf_off = 1 / (1 + np.exp(p['fall_rate'] * (day - p['fall_day'])))
     LAI_deciduous_actual = p["LAI_max_deciduous"] * leaf_on * leaf_off

--- a/energy_balance_rc_bck.py
+++ b/energy_balance_rc_bck.py
@@ -113,11 +113,10 @@ def get_model_config() -> Dict[str, Any]:
         shoulder_1_start=90, shoulder_1_end=150,
         shoulder_2_start=250, shoulder_2_end=300,
         snow_season_end=120, snow_season_start=280,
-        
-        # Phenology (deciduous)
-        growth_day=140, fall_day=270,
-        growth_rate=0.1, fall_rate=0.1,
-        woody_area_index=0.35,
+
+        # Phenology (deciduous; ranged)
+        growth_day_range=(130, 150), fall_day_range=(260, 280),
+        growth_rate=0.1, fall_rate=0.1, woody_area_index=0.35,
 
         # --- Trunk parameters ---------------------------------------------
         A_trunk_plan=0.03, A_trunk_vert=0.08,
@@ -209,6 +208,13 @@ def get_baseline_parameters(config: Dict, coniferous_fraction: float = 0.0) -> D
         p['u_ref'] = np.random.uniform(*p['u_ref_range'])
         del p['u_ref_range']
 
+    if 'growth_day_range' in p:
+        p['growth_day'] = np.random.uniform(*p['growth_day_range'])
+        del p['growth_day_range']
+    if 'fall_day_range' in p:
+        p['fall_day'] = np.random.uniform(*p['fall_day_range'])
+        del p['fall_day_range']
+
     u = p['u_ref']  # reference wind (m s⁻¹)
 
     # --- Species-specific parameters ---
@@ -286,7 +292,7 @@ def update_dynamic_parameters(p: Dict, day: int, hour: float, S: dict, L: float)
     )
     p["Q_solar"] = max(0.0, 1000.0 * cos_tz)
 
-    # --- Leaf phenology (mixed species) ---------------------------------------
+    # --- Leaf phenology (mixed species; sampled growth/fall days) ---------
     p["LAI_actual"] = 0.0
     deciduous_fraction = 1.0 - p['coniferous_fraction']
 


### PR DESCRIPTION
## Summary
- Replace fixed `growth_day` and `fall_day` with ranged parameters in modern and legacy simulators
- Sample the new day-of-year ranges during baseline parameter setup and use them in phenology calculations
- Update phenology comments to reflect sampled growth and senescence timing

## Testing
- `python -m py_compile energy_balance_rc.py energy_balance_rc_bck.py`
- `python energy_balance_rc.py`
- `python energy_balance_rc_bck.py`


------
https://chatgpt.com/codex/tasks/task_e_688ebd4a3f04832199cd2bc06fdbe8ad