### PR TITLE
Add configurable daily temperature noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ samples within these ranges (e.g., temperature offsets, humidity, precipitation
 probabilities), enabling Monte Carlo style analyses rather than relying on single
 deterministic values.
 
+One such parameter is `T_daily_noise_std`, which sets the standard deviation (K)
+for daily stochastic temperature forcing. A suggested range of 1–2 K captures
+typical day-to-day variability.
+
 ## Installation
 
 This project uses Python. We recommend using `uv` to manage dependencies in a virtual environment.

--- a/energy_balance_rc.py
+++ b/energy_balance_rc.py
@@ -89,6 +89,7 @@ def get_model_config() -> Dict[str, Any]:
         summer_day_start=150, summer_day_end=250, shoulder_1_start=90,
         shoulder_1_end=150, shoulder_2_start=250, shoulder_2_end=300,
         snow_season_end=120, snow_season_start=280,
+        T_daily_noise_std_range=(1.0, 2.0),  # Daily temperature noise std dev (K)
         # --- Phenology (Fixed) --------------------------------------------
         growth_day=140, fall_day=270, growth_rate=0.1, fall_rate=0.1,
         woody_area_index=0.35,
@@ -187,7 +188,7 @@ def update_dynamic_parameters(p: Dict, day: int, hour: float, S: dict, L: float,
     # --- Air temperature: annual + diurnal + STOCHASTIC offset --------------
     day_angle = 2 * np.pi * (day - 1) / 365.0
     p["T_large_scale"] = 273.15 + p['T_annual_mean_offset'] - p['T_seasonal_amplitude'] * np.cos(day_angle) \
-                         + rng.normal(0, 1.5) # Daily stochastic temp
+                         + rng.normal(0, p['T_daily_noise_std'])  # Daily stochastic temp
     p["T_atm"] = p["T_large_scale"] - p['T_diurnal_amplitude'] * np.cos(2 * np.pi * (hour - p['T_hour_peak_diurnal']) / 24.0)
     p['ea'] = p['mean_relative_humidity'] * esat_kPa(p['T_atm'])
     swc_frac = S['SWC_mm'] / p['SWC_max_mm']

--- a/energy_balance_rc_bck.py
+++ b/energy_balance_rc_bck.py
@@ -102,6 +102,7 @@ def get_model_config() -> Dict[str, Any]:
         T_seasonal_amplitude=22.0, # °C
         T_diurnal_amplitude=6.0,   # °C
         T_hour_peak_diurnal=4.0,   # hour of min temp
+        T_daily_noise_std=1.5,     # std dev for daily temp noise (K; suggested 1-2)
         # RH forcing
         mean_relative_humidity=0.70,
         # Precip forcing
@@ -253,7 +254,8 @@ def update_dynamic_parameters(p: Dict, day: int, hour: float, S: dict, L: float)
     """Update meteorological forcing and derived parameters for the current step."""
     # --- Air temperature: annual + diurnal harmonic ------------------------------
     day_angle = 2 * np.pi * (day - 1) / 365.0
-    p["T_large_scale"] = 273.15 + p['T_annual_mean_offset'] - p['T_seasonal_amplitude'] * np.cos(day_angle)
+    p["T_large_scale"] = 273.15 + p['T_annual_mean_offset'] - p['T_seasonal_amplitude'] * np.cos(day_angle) \
+                         + np.random.normal(0, p['T_daily_noise_std'])
     p["T_atm"] = p["T_large_scale"] - p['T_diurnal_amplitude'] * np.cos(2 * np.pi * (hour - p['T_hour_peak_diurnal']) / 24.0)
 
     # --- Ambient vapour pressure (for VPD calculations) -------------------------


### PR DESCRIPTION
## Summary
- Make daily temperature noise amplitude configurable via `T_daily_noise_std`
- Replace hard-coded temperature noise in stochastic forcing with config value
- Document recommended range for daily noise

## Testing
- `python -m py_compile energy_balance_rc.py energy_balance_rc_bck.py`
- `python energy_balance_rc.py`

------
https://chatgpt.com/codex/tasks/task_e_688ebd4c8cc883219b2cc7d433b7c3b1