### PR TITLE
Enable configurable roughness length ranges

### DIFF
--- a/energy_balance_rc.py
+++ b/energy_balance_rc.py
@@ -68,7 +68,10 @@ def get_model_config() -> Dict[str, Any]:
         T_MIN=180.0, T_MAX=330.0, DT_CLIP=15.0, SWE_SMOOTHING=0.01,
         CANOPY_MIN_H=10.0, H_atm=100.0, tau_adv=3600.0,
         # --- Aerodynamic parameters (some ranged) ------------------------
-        z_ref_h=15.0, z0_can=1.5, z_ref_soil=2.0, z0_soil=0.01,
+        z_ref_h=15.0,
+        z0_can_range=(1.0, 2.0),  # canopy roughness length range (m)
+        z_ref_soil=2.0,
+        z0_soil_range=(0.005, 0.02),  # soil roughness length range (m)
         h_trunk_const=5.0, h_trunk_wind_coeff=4.0,
         u_ref_range=(1.0, 5.0),
         # --- Soil & Water parameters ( 일부는 범위로 지정) --------------------

--- a/energy_balance_rc_bck.py
+++ b/energy_balance_rc_bck.py
@@ -70,10 +70,10 @@ def get_model_config() -> Dict[str, Any]:
         tau_adv=3600.0,
 
         # --- Aerodynamic parameters (some ranged) -------------------------
-        z_ref_h=15.0,     # reference height for h_can (m)
-        z0_can=1.5,       # canopy roughness length (m)
-        z_ref_soil=2.0,   # reference height for h_soil (m)
-        z0_soil=0.01,     # soil roughness length (m)
+        z_ref_h=15.0,               # reference height for h_can (m)
+        z0_can_range=(1.0, 2.0),    # canopy roughness length range (m)
+        z_ref_soil=2.0,             # reference height for h_soil (m)
+        z0_soil_range=(0.005, 0.02),# soil roughness length range (m)
         h_trunk_const=5.0,    # constant term for h_trunk
         h_trunk_wind_coeff=4.0, # wind coefficient for h_trunk
         u_ref_range=(1.0, 5.0),
@@ -208,6 +208,14 @@ def get_baseline_parameters(config: Dict, coniferous_fraction: float = 0.0) -> D
     if 'u_ref_range' in p:
         p['u_ref'] = np.random.uniform(*p['u_ref_range'])
         del p['u_ref_range']
+
+    # Sample roughness lengths if ranges are provided
+    if 'z0_can_range' in p:
+        p['z0_can'] = np.random.uniform(*p['z0_can_range'])
+        del p['z0_can_range']
+    if 'z0_soil_range' in p:
+        p['z0_soil'] = np.random.uniform(*p['z0_soil_range'])
+        del p['z0_soil_range']
 
     u = p['u_ref']  # reference wind (m s⁻¹)
 


### PR DESCRIPTION
## Summary
- allow `z0_can` and `z0_soil` to be specified as ranges and sampled at runtime
- sample these roughness lengths during baseline parameter initialization
- use the sampled values in aerodynamic conductance calculations

## Testing
- `python -m py_compile energy_balance_rc.py energy_balance_rc_bck.py`
- `python energy_balance_rc.py`
- `python energy_balance_rc_bck.py`


------
https://chatgpt.com/codex/tasks/task_e_688ebd71f2788321b3b82c81b176bb0a