### PR TITLE
Allow ranged phenology days

### DIFF
--- a/energy_balance_rc_bck.py
+++ b/energy_balance_rc_bck.py
@@ -115,8 +115,8 @@ def get_model_config() -> Dict[str, Any]:
         shoulder_2_start=250, shoulder_2_end=300,
         snow_season_end=120, snow_season_start=280,
         
-        # Phenology (deciduous)
-        growth_day=140, fall_day=270,
+        # Phenology (deciduous; ranged DOY)
+        growth_day_range=(130, 150), fall_day_range=(260, 280),
         growth_rate=0.1, fall_rate=0.1,
         woody_area_index=0.35,
 
@@ -301,7 +301,7 @@ def update_dynamic_parameters(p: Dict, day: int, hour: float, S: dict, L: float)
     )
     p["Q_solar"] = max(0.0, 1000.0 * cos_tz)
 
-    # --- Leaf phenology (mixed species) ---------------------------------------
+    # --- Leaf phenology (mixed species; sampled onset/offset) -------------
     p["LAI_actual"] = 0.0
     deciduous_fraction = 1.0 - p['coniferous_fraction']
 


### PR DESCRIPTION
## Summary
- Sample growth and senescence days from new `growth_day_range` and `fall_day_range`
- Use sampled onset and offset in phenology calculations for both main and legacy models

## Testing
- `python -m py_compile energy_balance_rc.py energy_balance_rc_bck.py`
- `python - <<'PY'
import energy_balance_rc
import energy_balance_rc_bck

sim = energy_balance_rc.ForestSimulator(coniferous_fraction=0.5, stem_density=800, carbon_stock_kg_m2=15.0, weather_seed=42)
print('main model growth_day', sim.p['growth_day'])
print('main model fall_day', sim.p['fall_day'])

config_bck = energy_balance_rc_bck.get_model_config()
params_bck = energy_balance_rc_bck.get_baseline_parameters(config_bck, coniferous_fraction=0.5)
print('legacy model growth_day', params_bck['growth_day'])
print('legacy model fall_day', params_bck['fall_day'])
PY`

------
https://chatgpt.com/codex/tasks/task_e_688ec26d93ec832186bb0dae65e8aba0